### PR TITLE
fix: do not require bearer for unauthenticated routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ app.use(createAuthMiddleware(app));
 The register components middleware adds security schemes with AUTH_URL based on the environment. As environment variables aren't available until a context is established, the schemes are added on the first request.
 
 ```typescript
-// Example environment variables:
-// AUTH_URL: 'https://auth.example.com'
+// Required environment variables:
+interface Bindings {
+  // The url of the auth service that is references from the swagger file
+  AUTH_URL: string;
+}
 
 const app = new OpenAPIHono<{
   Bindings: Bindings;

--- a/src/middlewares/authentication.ts
+++ b/src/middlewares/authentication.ts
@@ -149,28 +149,30 @@ export function createAuthMiddleware<H extends AuthenticationGenerics>(
     if (definition && 'route' in definition) {
       const requiredPermissions = definition.route.security?.[0]?.Bearer;
 
-      const authHeader = ctx.req.header('authorization') || '';
-      const [authType, bearer] = authHeader.split(' ');
-      if (authType?.toLowerCase() !== 'bearer' || !bearer) {
-        throw new HTTPException(403, {
-          message: 'Missing bearer token',
-        });
-      }
+      if (requiredPermissions) {
+        const authHeader = ctx.req.header('authorization') || '';
+        const [authType, bearer] = authHeader.split(' ');
+        if (authType?.toLowerCase() !== 'bearer' || !bearer) {
+          throw new HTTPException(403, {
+            message: 'Missing bearer token',
+          });
+        }
 
-      const token = decodeJwt(bearer);
+        const token = decodeJwt(bearer);
 
-      if (!token || !(await isValidJwtSignature(ctx, token))) {
-        throw new HTTPException(403, { message: 'Invalid JWT signature' });
-      }
+        if (!token || !(await isValidJwtSignature(ctx, token))) {
+          throw new HTTPException(403, { message: 'Invalid JWT signature' });
+        }
 
-      ctx.set('user_id', token.payload.sub);
+        ctx.set('user_id', token.payload.sub);
 
-      const permissions = token.payload.permissions || [];
-      if (
-        requiredPermissions?.length &&
-        !requiredPermissions.some((scope) => permissions.includes(scope))
-      ) {
-        throw new HTTPException(403, { message: 'Unauthorized' });
+        const permissions = token.payload.permissions || [];
+        if (
+          requiredPermissions?.length &&
+          !requiredPermissions.some((scope) => permissions.includes(scope))
+        ) {
+          throw new HTTPException(403, { message: 'Unauthorized' });
+        }
       }
     }
 

--- a/src/middlewares/register-component.ts
+++ b/src/middlewares/register-component.ts
@@ -20,14 +20,14 @@ export type RegisterComponentGenerics = {
 export function registerComponent<H extends RegisterComponentGenerics>(
   app: OpenAPIHono<H>,
 ) {
-  app.use(async (ctx: Context<H>, next: Next) => {
+  return async (ctx: Context<H>, next: Next) => {
     if (!initiated) {
       app.openAPIRegistry.registerComponent('securitySchemes', 'Bearer', {
         type: 'oauth2',
         scheme: 'bearer',
         flows: {
           implicit: {
-            authorizationUrl: `${ctx.env.AUTH_URL}/authorize`,
+            authorizationUrl: ctx.env.AUTH_URL,
             scopes: {
               openid: 'Basic user information',
               email: 'User email',
@@ -41,5 +41,5 @@ export function registerComponent<H extends RegisterComponentGenerics>(
     }
 
     return await next();
-  });
+  };
 }

--- a/test/register-components.spec.ts
+++ b/test/register-components.spec.ts
@@ -1,0 +1,87 @@
+import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
+import { describe, expect, it } from 'vitest';
+import { testClient } from 'hono/testing';
+import { registerComponent } from '../src/middlewares/register-component';
+
+interface Bindings {
+  AUTH_URL: string;
+}
+
+function getTestApp(security: string[] = []) {
+  const rootApp = new OpenAPIHono<{
+    Bindings: Bindings;
+  }>();
+
+  rootApp.use(registerComponent(rootApp));
+
+  const app = rootApp
+    // --------------------------------
+    // GET /
+    // --------------------------------
+    .openapi(
+      createRoute({
+        tags: ['test'],
+        method: 'get',
+        path: '/',
+        security: [
+          {
+            Bearer: security,
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Status',
+          },
+        },
+      }),
+      async (ctx) => {
+        return ctx.text('Hello World');
+      },
+    )
+    .doc('/spec', (c) => ({
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'API',
+      },
+      servers: [
+        {
+          url: new URL(c.req.url).origin,
+          description: 'Current environment',
+        },
+      ],
+    }));
+
+  return testClient(app, {
+    AUTH_URL: 'https://example.com/authorize',
+  });
+}
+
+describe('registerComponents', () => {
+  it('Should add the securitySchema to the ', async () => {
+    const appClient = getTestApp();
+
+    const response = await appClient.spec.$get();
+
+    expect(response.status).toBe(200);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const spec: any = await response.json();
+
+    expect(spec.components.securitySchemes).toEqual({
+      Bearer: {
+        type: 'oauth2',
+        scheme: 'bearer',
+        flows: {
+          implicit: {
+            authorizationUrl: 'https://example.com/authorize',
+            scopes: {
+              openid: 'Basic user information',
+              email: 'User email',
+              profile: 'User profile information',
+            },
+          },
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
Also changed so that the registerComponents returned the middleware rather than adding it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced documentation for authentication middleware and environment variable requirements in the README.
	- Introduced a new endpoint for unauthenticated requests, returning a 200 status with a message.
	- Added unit tests for the `registerComponent` middleware, ensuring proper integration of security schema in OpenAPI documentation.

- **Bug Fixes**
	- Optimized authorization checks to occur only when required permissions are defined, improving efficiency.

- **Documentation**
	- Updated descriptions for `AUTH_URL` in the `Bindings` interface and refined comment structures for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->